### PR TITLE
Added option to include a image to question text

### DIFF
--- a/moodle_questions/questions/abstract/question.py
+++ b/moodle_questions/questions/abstract/question.py
@@ -19,8 +19,8 @@ class Question(metaclass=ABCMeta):
         :type question_text: str
         :param question_text: text of the question
         
-    :type image_name:str
-    :param image_name: name/path of optional image aside the text of the question
+        :type image_name:str
+        :param image_name: name/path of optional image aside the text of the question
     
         :type default_mark: float
         :param default_mark: the default mark
@@ -115,9 +115,8 @@ class Question(metaclass=ABCMeta):
 
         questiontext = et.SubElement(question, "questiontext", {"format": "html"})
         text = et.SubElement(questiontext, "text")
-        
         if self.image_name:
-            self.question_text = self.question_text+'<p><img src="@@PLUGINFILE@@/' + self.image_name.split(os.sep)[-1]+'"<br></p>'
+            self.question_text = self.question_text+'<p><img src="@@PLUGINFILE@@/' + self.image_name.split(os.sep)[-1]+'"></p>'
         text.text = cdata_str(self.question_text)
     
         if self.image_name:
@@ -137,6 +136,9 @@ class Question(metaclass=ABCMeta):
 
         idnumber = et.SubElement(question, "idnumber")
         idnumber.text = estr(self.id_number)
+                
+        shuffleanswers=et.SubElement(question, "shuffleanswers")
+        shuffleanswers.text = 'true' if self.shuffle else 'false'
         return question
 
     @classmethod


### PR DESCRIPTION
Hello.
I created this pull request for enhance question.py so it is possible to add an image to the question text. Image is optional so you can use:
```python
q2 = MultipleChoiceQuestion(name = "Celsius Fahrenheit Equivalency IMG",
                            question_text = "At what temperature value do the Fahrenheit and Celsius scales have the same numerical value?",
                            image_name="image1.jpg",
                            default_mark = 1,
                            correct_feedback = "Correct!",
                            shuffle=True)
```
or
```python
q2 = MultipleChoiceQuestion(name = "Celsius Fahrenheit Equivalency IMG",
                            question_text = "At what temperature value do the Fahrenheit and Celsius scales have the same numerical value?",
                            default_mark = 1,
                            correct_feedback = "Correct!",
                            shuffle=True)
```
I created a second commit just to create the appropiate tag to shuffle the answers in a question.

It would be great if you accept the pull request and publish the new package in PYPI.
Cheers.